### PR TITLE
Add Leaflet-based rainfall map

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,8 @@
     "@deck.gl/geo-layers": "^9.0.0",
     "@deck.gl/react": "^9.0.0",
     "@rain/common": "workspace:*",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/packages/frontend/public/index.html
+++ b/packages/frontend/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Rainfall 3D Histogram Map</title>
+    <title>Taiwan Rainfall Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,9 +1,9 @@
-import RainfallMap from "./components/RainfallMap";
+import LeafletMap from "./components/LeafletMap";
 
 export default function App() {
   return (
     <div style={{ width: "100vw", height: "100vh" }}>
-      <RainfallMap />
+      <LeafletMap />
     </div>
   );
 }

--- a/packages/frontend/src/components/LeafletMap.tsx
+++ b/packages/frontend/src/components/LeafletMap.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from "react";
+import { MapContainer, TileLayer, CircleMarker, Popup, ScaleControl } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import { RainfallDataPoint } from "@rain/common/src/types";
+import { getRainfallData } from "../api/rainfallApi";
+
+// Utility functions to style markers
+function getRainfallColor(value: number): string {
+  if (value < 50) return "#87CEEB";
+  if (value < 100) return "#1E90FF";
+  if (value < 150) return "#0066CC";
+  return "#003399";
+}
+
+function getRainfallRadius(value: number): number {
+  return Math.max(8, Math.min(25, value / 8));
+}
+
+export default function LeafletMap() {
+  const [data, setData] = useState<RainfallDataPoint[]>([]);
+
+  useEffect(() => {
+    getRainfallData().then(setData).catch(console.error);
+  }, []);
+
+  return (
+    <div style={{ width: "100%", height: "100%", position: "relative" }}>
+      <MapContainer center={[23.8, 120.9]} zoom={7} style={{ width: "100%", height: "100%" }}>
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution="© OpenStreetMap contributors"
+          maxZoom={18}
+        />
+        {data.map((station, idx) => (
+          <CircleMarker
+            key={idx}
+            center={[station.lat, station.lon]}
+            radius={getRainfallRadius(station.value)}
+            pathOptions={{
+              color: "#ffffff",
+              weight: 2,
+              fillColor: getRainfallColor(station.value),
+              fillOpacity: 0.8,
+            }}
+          >
+            <Popup>
+              <div className="rainfall-popup">
+                <h4 style={{ margin: "5px 0", color: getRainfallColor(station.value) }}>
+                  {station.timestamp ? new Date(station.timestamp).toLocaleString() : "Rainfall"}
+                </h4>
+                <p style={{ margin: "5px 0" }}>
+                  <strong>Rainfall:</strong> {station.value}mm
+                </p>
+                <p style={{ margin: "5px 0", fontSize: "11px", color: "#666" }}>
+                  Coordinates: {station.lat.toFixed(4)}°N, {station.lon.toFixed(4)}°E
+                </p>
+              </div>
+            </Popup>
+          </CircleMarker>
+        ))}
+        <ScaleControl position="bottomleft" />
+      </MapContainer>
+      <div className="controls">
+        <h4 style={{ margin: "0 0 5px 0" }}>Taiwan Rainfall Map</h4>
+        <p style={{ margin: 0, color: "#666" }}>Click circles for details</p>
+      </div>
+      <div className="legend">
+        <h3>Rainfall Levels</h3>
+        <div className="legend-item">
+          <div className="legend-color" style={{ background: "#87CEEB" }}></div>
+          <span>Light (0-50mm)</span>
+        </div>
+        <div className="legend-item">
+          <div className="legend-color" style={{ background: "#1E90FF" }}></div>
+          <span>Moderate (50-100mm)</span>
+        </div>
+        <div className="legend-item">
+          <div className="legend-color" style={{ background: "#0066CC" }}></div>
+          <span>Heavy (100-150mm)</span>
+        </div>
+        <div className="legend-item">
+          <div className="legend-color" style={{ background: "#003399" }}></div>
+          <span>Very Heavy (150mm+)</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -4,3 +4,56 @@ html, body, #root, main {
   margin: 0;
   padding: 0;
 }
+
+body {
+  font-family: Arial, sans-serif;
+  background: #f0f0f0;
+}
+
+.legend {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  font-size: 12px;
+}
+
+.legend h3 {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #333;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  margin: 5px 0;
+}
+
+.legend-color {
+  width: 20px;
+  height: 12px;
+  margin-right: 8px;
+  border-radius: 2px;
+}
+
+.rainfall-popup {
+  text-align: center;
+  font-weight: bold;
+}
+
+.controls {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- switch frontend map implementation to a Leaflet-based component
- style the map with legend and controls similar to the provided example
- update page title and include Leaflet & React-Leaflet dependencies

## Testing
- `pnpm --filter @rain/frontend lint` *(fails: ESLint couldn't find config)*
- `pnpm --filter @rain/frontend build` *(fails: vite not found, node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f755eac8322b36637f3a35a491c