### PR TITLE
Add CSV upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A full-stack TypeScript monorepo that turns rainfall measurements into an intera
 - Modular Data Provider pattern – swap CSV, REST API, or DB with one line of config
 - Type-safe end-to-end (shared interfaces in packages/common)
 - Monorepo with Yarn/PNPM workspaces + Turborepo for fast builds
+- Upload new rainfall CSV directly from the web UI
 - Live-reload dev servers (`pnpm dev`)
 - Docker multi-stage images & docker-compose stack
 - GitHub Actions pipeline template (build ➜ test ➜ docker ➜ deploy)
@@ -157,6 +158,7 @@ Open <http://localhost:5173/> (use `/`, not `/index.html`).
 1. Navigate to <http://localhost:5173/>.
 2. Confirm the map loads and that `/api/rainfall` returns JSON.
 3. You should see three blue extruded bars from the sample dataset.
+4. Upload your own CSV via the form at the top of the page.
 
 ### 6. Production with Docker (optional)
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,7 +14,8 @@
     "csv-parse": "^5.5.0",
     "dotenv": "^16.4.0",
     "express": "^4.19.0",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -1,6 +1,8 @@
 // backend/src/server.ts
 import express from "express";
 import cors from "cors";
+import multer from "multer";
+import { writeFile } from "node:fs/promises";
 import { CsvDataProvider } from "./dataProviders/CsvDataProvider.js";
 import { ApiDataProvider } from "./dataProviders/ApiDataProvider.js";
 import { makeRainfallController } from "./controllers/rainfallController.js";
@@ -8,12 +10,27 @@ import { makeRainfallController } from "./controllers/rainfallController.js";
 export function buildServer() {
   const app = express();
   app.use(cors());
+  const upload = multer();
+  const csvPath = process.env.CSV_FILE || "data/rainfall.csv";
+
+  app.post("/api/upload", upload.single("file"), async (req, res) => {
+    if (!req.file) {
+      return res.status(400).json({ error: "no_file" });
+    }
+    try {
+      await writeFile(csvPath, req.file.buffer);
+      res.json({ ok: true });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: "save_failed" });
+    }
+  });
 
   // choose provider via env
   const provider =
     process.env.DATA_SOURCE === "api"
       ? new ApiDataProvider(process.env.API_URL!)
-      : new CsvDataProvider(process.env.CSV_FILE || "data/rainfall.csv");
+      : new CsvDataProvider(csvPath);
 
   app.get("/api/rainfall", makeRainfallController(provider));
   return app;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,9 +1,13 @@
+import { useState } from "react";
 import LeafletMap from "./components/LeafletMap";
+import CsvUpload from "./components/CsvUpload";
 
 export default function App() {
+  const [refreshToken, setRefreshToken] = useState(0);
   return (
     <div style={{ width: "100vw", height: "100vh" }}>
-      <LeafletMap />
+      <CsvUpload onUpload={() => setRefreshToken(Date.now())} />
+      <LeafletMap refreshToken={refreshToken} />
     </div>
   );
 }

--- a/packages/frontend/src/api/rainfallApi.ts
+++ b/packages/frontend/src/api/rainfallApi.ts
@@ -6,3 +6,10 @@ export async function getRainfallData(): Promise<RainfallDataPoint[]> {
   if (!res.ok) throw new Error("Network error");
   return res.json();
 }
+
+export async function uploadCsv(file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await fetch("/api/upload", { method: "POST", body: formData });
+  if (!res.ok) throw new Error("Upload failed");
+}

--- a/packages/frontend/src/components/CsvUpload.tsx
+++ b/packages/frontend/src/components/CsvUpload.tsx
@@ -1,0 +1,29 @@
+import React, { useRef, useState } from "react";
+import { uploadCsv } from "../api/rainfallApi";
+
+export default function CsvUpload({ onUpload }: { onUpload?: () => void }) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const handleUpload = async () => {
+    const file = inputRef.current?.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      await uploadCsv(file);
+      onUpload?.();
+    } catch (err) {
+      console.error(err);
+      alert("Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+  return (
+    <div style={{ margin: "10px 0" }}>
+      <input type="file" accept=".csv" ref={inputRef} />
+      <button onClick={handleUpload} disabled={uploading} style={{ marginLeft: 8 }}>
+        {uploading ? "Uploading..." : "Upload"}
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/LeafletMap.tsx
+++ b/packages/frontend/src/components/LeafletMap.tsx
@@ -16,12 +16,12 @@ function getRainfallRadius(value: number): number {
   return Math.max(8, Math.min(25, value / 8));
 }
 
-export default function LeafletMap() {
+export default function LeafletMap({ refreshToken }: { refreshToken?: number }) {
   const [data, setData] = useState<RainfallDataPoint[]>([]);
 
   useEffect(() => {
     getRainfallData().then(setData).catch(console.error);
-  }, []);
+  }, [refreshToken]);
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>


### PR DESCRIPTION
## Summary
- allow backend to accept CSV uploads
- expose an upload API from the frontend
- add CsvUpload component and wire up in App
- refresh map data after uploading
- mention CSV upload capability in README

## Testing
- `pnpm turbo run test` *(fails: Command "turbo" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6abb8d608322b13c65dee59e4e9f